### PR TITLE
Adding update to backup location based on new world save location

### DIFF
--- a/src/backups.js
+++ b/src/backups.js
@@ -15,6 +15,12 @@ module.exports = class ValheimBackups {
             this.worldsPath = path.join(os.homedir(), '.config/unity3d/IronGate/Valheim/worlds');
         }
 
+        // patch 0.209.8 (client) and possibly 8977163 dedicated server introduced a new save location "_local"
+        // for client and dedicated servers local worlds (non-cloud saved) - see https://steamdb.info/patchnotes/8954338/
+        if(!manager.config.legacyBackupLocation) {
+            this.worldsPath += "_local";
+        }
+
         this.manager = manager;
         this.buFrequency = manager.config.manager.backupFrequency;
         this.buLimit = manager.config.manager.backupRetention;

--- a/src/types/defaultConfig.js
+++ b/src/types/defaultConfig.js
@@ -4,6 +4,9 @@ module.exports = {
     manager: {
         configLocation: './vmConfig.json',
         serverLocation: './server/',
+
+        //patches < 0.209.8 (client) and possibly build 8977163 dedicated server need to set this as true
+        legacyBackupLocation: false,
         backupFrequency: 60,
         backupRetention: 6,
         autoOpenPorts: false,


### PR DESCRIPTION
- Update the defaultConfig to have the legacyBackupLocation parameter. The default value set to false, as the new dedicated server world locations are under worlds_local instead of worlds
- Set the worldspath used in the backup logic based on the legacyBackupLocation parameter.