### PR TITLE
Fixed an issue with the launcher not running on Windows due to a security incident in later versions of NodeJS

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -47,6 +47,11 @@ module.exports = class ValheimLauncher {
 
         // Define the OS specific variables and functions
         if (manager.config.manager.operatingSystem == 'win32') {
+            // This is necessary for newer NodeJS versions as the there was a change in response to
+            // a security incident - see below:
+            // https://github.com/nodejs/node/issues/52554
+            // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+            this.spawnOptions.shell = true;
             this.generateLauncher = this.generateWindowsLauncher;
             this.launchFile = path.join(this.valheimPath, 'launcher.bat');
             this.processName = 'valheim_server.exe';


### PR DESCRIPTION
See the following issue/blog posting:

https://github.com/nodejs/node/issues/52554
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2

This should be ok as the launcher is generated by the application, but we are trusting that no one has tampered with it after the fact before it launches.